### PR TITLE
An example of goog.module

### DIFF
--- a/goog-module.html
+++ b/goog-module.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src="node_modules/google-closure-library/closure/goog/base.js"></script>
+  <script src="goog-module/myproject-deps.js"></script>
+  <script>
+    goog.require('myproject.main');
+  </script>
+</head>
+
+<body>
+  <script>
+    myproject.main.bootstrap();
+  </script>
+</body>
+
+</html>

--- a/goog-module/class-module.js
+++ b/goog-module/class-module.js
@@ -1,0 +1,10 @@
+goog.module('myproject.Foo');
+
+class Foo {
+
+  sayHello() {
+    console.log('Hi! This is goog.module based class');
+  }
+}
+
+exports = Foo;

--- a/goog-module/main.js
+++ b/goog-module/main.js
@@ -1,0 +1,9 @@
+goog.module('myproject.main');
+goog.module.declareLegacyNamespace();
+
+const Foo = goog.require('myproject.Foo');
+
+exports.bootstrap = () => {
+  const foo = new Foo();
+  foo.sayHello();
+}

--- a/goog-module/myproject-deps.js
+++ b/goog-module/myproject-deps.js
@@ -1,0 +1,3 @@
+goog.addDependency('../../../../goog-module/class-module.js', ['myproject.Foo'], [], {'lang': 'es6', 'module': 'goog'});
+goog.addDependency('../../../../goog-module/main.js', ['myproject.main'], ['myproject.Foo'], {'lang': 'es6', 'module': 'goog'});
+


### PR DESCRIPTION
ref. [goog.module: an ES6 module like alternative to goog.provide · google/closure-library Wiki](https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide)